### PR TITLE
Voice Data & random tweaks

### DIFF
--- a/_static/mumble.css
+++ b/_static/mumble.css
@@ -5,3 +5,15 @@
 th {
 	background-color: #adadad;
 }
+
+table.bits8 {
+	text-align: center;
+	table-layout: fixed;
+	width: 300px;
+}
+
+table.bits16 {
+	text-align: center;
+	table-layout: fixed;
+}
+

--- a/conf.py
+++ b/conf.py
@@ -2,6 +2,9 @@
 
 import sys, os
 
+# on_rtd is whether we are on readthedocs.org
+on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
+
 extensions = [
 	'sphinx.ext.pngmath',
 ]
@@ -32,16 +35,22 @@ exclude_patterns = ['_build']
 
 pygments_style = 'sphinx'
 
-html_theme = 'default'
-html_theme_options = {
-	'footerbgcolor':    '#555555',
-	'relbarbgcolor':    '#222222',
-	'sidebarbgcolor':   '#333333',
-	'linkcolor':        '#696969',
-	'visitedlinkcolor': '#adadad',
-	'sidebarlinkcolor': '#cacaca',
-	'headtextcolor':    '#000000',
-}
+if not on_rtd:  # only import and set the theme if we're building docs locally
+    import sphinx_rtd_theme
+    html_theme = 'sphinx_rtd_theme'
+    html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
+else:
+    html_theme = 'default'
+
+    html_theme_options = {
+            'footerbgcolor':    '#555555',
+            'relbarbgcolor':    '#222222',
+            'sidebarbgcolor':   '#333333',
+            'linkcolor':        '#696969',
+            'visitedlinkcolor': '#adadad',
+            'sidebarlinkcolor': '#cacaca',
+            'headtextcolor':    '#000000',
+    }
 
 # Add any paths that contain custom themes here, relative to this directory.
 #html_theme_path = []

--- a/index.rst
+++ b/index.rst
@@ -1,10 +1,11 @@
 Mumble Protocol Documentation
 =============================
 
-Contents:
+Contents
+--------
 
 .. toctree::
-   :maxdepth: 2
+   :maxdepth: 3
 
    introduction
    overview
@@ -13,8 +14,10 @@ Contents:
    voice_data
 
 
-Indices and tables
-==================
+.. # These are empty pages:
 
-* :ref:`genindex`
-* :ref:`search`
+.. # Indices and tables
+.. # ==================
+
+.. # * :ref:`genindex`
+.. # * :ref:`search`

--- a/introduction.rst
+++ b/introduction.rst
@@ -2,8 +2,9 @@ Introduction
 ============
 
 This document is meant to be a reference for the Mumble VoIP 1.2.X
-server-client communication protocol.  It reflects the state of the
-protocol implemented in the Mumble 1.2.2 client and might be outdated
-by the time you are reading this. Be sure to check for newer revisions
-of this document on our website \url{http://www.mumble.info}. At the
-moment this document is work in progress.
+server-client communication protocol. It reflects the state of the protocol
+implemented in the Mumble 1.2.8 client and might be outdated by the time you
+are reading this. Be sure to check for newer revisions of this document at
+http://mumble-protocol.readthedocs.org/.
+
+This document is a constant work in progress.


### PR DESCRIPTION
Sorry for the messy PR. I'll break it into three if someone actually wants that. :stuck_out_tongue:

Main change is rewriting most of the voice_data.rst. The original version (mumble-voip/mumble@46f27d798281863262b0d0dc4dd947b6d4e8d776) was written by some silly person who had no idea how the stuff works. Hopefully that person has learned some by now. :)

That rewrite did include some representational changes as well, biggest of which was how the bitfields are described. When consuming the documentation I found it difficult to try deciphering the multi-value bytes so I'm now tried more verbal explanation for them.

Other large-ish change was adding the RTD theme to the conf.py. This makes it easier to figure out the layout while modifying the documentation locally but it does mean everyone who touches it needs to install the layout as it is not stored in the repository. (https://github.com/snide/sphinx_rtd_theme)

Preview (while my screen stays up): http://jubjub.jubjubnest.net:8080/index.html
