### PR TITLE
Fix use of pronouns

### DIFF
--- a/establishing_connection.rst
+++ b/establishing_connection.rst
@@ -221,11 +221,11 @@ currently on the server, including the user that is currently connecting.
 Server sync
 -----------
 
-The client has now received a copy of the parts of the server state he
+The client has now received a copy of the parts of the server state it
 needs to know about. To complete the synchronization the server transmits
 a ServerSync message containing the session id of the clients session,
 the maximum bandwidth allowed on this server, the servers welcome text
-as well as the permissions the client has in the channel he ended up.
+as well as the permissions the client has in the channel it ended up in.
 
 For more information pease refer to the Mumble.proto file [#f1]_.
 

--- a/voice_data.rst
+++ b/voice_data.rst
@@ -289,7 +289,7 @@ Whispering
 
 Normal talking can be heard by the users of the current channel and all linked
 channels as long as the speaker has Talk permission on these channels. If the
-speaker wishes to broadcast the voice to specific users or channels, he may
+speaker wishes to broadcast the voice to specific users or channels, they may
 use whispering. This is achieved by registering a voice target using the
 VoiceTarget message and specifying the target ID as the target in the first
 byte of the UDP packet.


### PR DESCRIPTION
* Use it/its for the "client" to be consistent with the rest of the docs
* Use neutral pronouns (they/them) for user/speaker